### PR TITLE
Replaced `getRecordValues` with `syncRecordValues`

### DIFF
--- a/api/html.js
+++ b/api/html.js
@@ -25,7 +25,7 @@ module.exports = async (req, res) => {
     })
   }
 
-  const overview = await call("getRecordValues", {
+  const overview = await call("synRecordValues", {
     requests: [
       {
         id,
@@ -34,13 +34,13 @@ module.exports = async (req, res) => {
     ]
   })
 
-  if(!overview.results[0].value) {
+  if(!overview.recordMap.block[id].value) {
     return res.json({
       error: "could not read Notion doc with this ID - make sure public access is enabled"
     })
   }
 
-  const contentIds = overview.results[0].value.content
+  const contentIds = overview.recordMap.block[id].value.content
 
   if(!contentIds) {
     return res.json({


### PR DESCRIPTION
The endpoint `getRecordValues` returns extra data that are not required. `syncRecordValues` returns only the requested data and nothing else.

For example. for the following payload requested at `getRecordValues` endpoint,

```json
{
	"requests": [
		{
			"table": "block",
			"id": "blockid",
			"version": -1
		}
	]
}
```

this was returned
![image](https://user-images.githubusercontent.com/34683631/110455833-156ff880-80f3-11eb-881b-a475190f6ff7.png)

But for `syncRecordValues` endpoint with the same payload, this was returned

![image](https://user-images.githubusercontent.com/34683631/110456307-9d560280-80f3-11eb-9f12-245233a47d2b.png)


